### PR TITLE
Add fsspec to pgstac optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 pgstac = [
+    "fsspec",
     "pypgstac",
     "psycopg[binary,pool]",
     "tqdm",


### PR DESCRIPTION
Tests won't run w/o fsspec and I _think_ this is the right optional dependency to drop them in.